### PR TITLE
Fix operator driver typo

### DIFF
--- a/dg5f_driver/src/dg5f_operator_driver.cpp
+++ b/dg5f_driver/src/dg5f_operator_driver.cpp
@@ -40,7 +40,7 @@ class dg5fDriver : public rclcpp::Node {
         "/joint_states", 10);
 
     subscription_ = this->create_subscription<std_msgs::msg::Float32MultiArray>(
-        "/taget_joint", 10,
+        "/target_joint", 10,
         std::bind(&dg5fDriver::topic_callback, this, std::placeholders::_1));
 
     timer_ = this->create_wall_timer(
@@ -83,7 +83,6 @@ class dg5fDriver : public rclcpp::Node {
 
   void timer_callback() {
     data = delto_client_->get_data();
-    // this->get_logger().info("Received data fr som DG5F");S?
     RCLCPP_INFO(this->get_logger(), "Received data from DG5F");
     // Publish joint states
     auto joint_state = sensor_msgs::msg::JointState();


### PR DESCRIPTION
## Summary
- fix typo in topic subscription `/target_joint`
- remove stray comment from timer callback

## Testing
- `g++ -fsyntax-only -std=c++17 -Wall -Wextra -Wpedantic -Idg5f_driver/include dg5f_driver/src/dg5f_operator_driver.cpp` *(fails: `rclcpp/executors/multi_threaded_executor.hpp: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68464df14e208330a81f9d065f872cfc